### PR TITLE
Wrap Editor._onCloze instead of Editor.onCloze

### DIFF
--- a/src/cloze_overlapper/editor.py
+++ b/src/cloze_overlapper/editor.py
@@ -185,7 +185,7 @@ def refreshEditor(editor):
 
 # Button callbacks
 
-def onInsertCloze(self, _old):
+def _onInsertCloze(self, _old):
     """Handles cloze-wraps when the add-on model is active"""
     if not checkModel(self.note.model(), fields=False, notify=False):
         return _old(self)
@@ -200,7 +200,7 @@ def onInsertCloze(self, _old):
         highest += 1
     # must start at 1
     highest = max(1, highest)
-    self.web.eval("wrap('[[oc%d::', ']]');" % highest)
+    self.web.eval("wrap2('[[oc%d::', ']]');" % highest)
 
 
 @editorSaveThen
@@ -432,7 +432,7 @@ def setupAdditionalHotkeys(editor):
 
 def initializeEditor():
     # Editor widget
-    Editor.onCloze = wrap(Editor.onCloze, onInsertCloze, "around")
+    Editor._onCloze = wrap(Editor._onCloze, _onInsertCloze, "around")
     Editor.onOlClozeButton = onOlClozeButton
     Editor.onOlOptionsButton = onOlOptionsButton
     Editor.onInsertMultipleClozes = onInsertMultipleClozes


### PR DESCRIPTION
#### Description

fixes #34 


#### Checklist:

*Please replace the space inside the brackets with an **x** and fill out the ellipses if the following items apply:*

- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [x] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [ ] Latest standard Anki 2.1 binary build [required for Anki-compatible 2.1 add-ons]
  - [ ] Latest alternative Anki 2.1 binary build
  - [x] Running Anki 2.1 from source - commit: af4d4af
  - [ ] Latest Anki 2.0 binary build [required for Anki 2.0-compatible add-ons]
- [x] I've tested my changes on at least one of the following platforms:
  - [x] Linux, version: Debian bullseye
  - [ ] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
