### PR TITLE
reset font size

### DIFF
--- a/docs/templates/styling.css
+++ b/docs/templates/styling.css
@@ -18,7 +18,7 @@ html {
 
 .card {
   font-family: "Helvetica LT Std", Helvetica, Arial, Sans;
-  font-size: 150%;
+  font-size: 100%;
   text-align: center;
   color: black;
   background-color: white;
@@ -86,7 +86,7 @@ html {
 }
 
 #btn-reveal {
-  font-size: 0.5em;
+  font-size: 0.7em;
 }
 
 .mobile #btn-reveal {

--- a/src/cloze_overlapper/template.py
+++ b/src/cloze_overlapper/template.py
@@ -256,7 +256,7 @@ html {
 
 .card {
   font-family: "Helvetica LT Std", Helvetica, Arial, Sans;
-  font-size: 150%;
+  font-size: 100%;
   text-align: center;
   color: black;
   background-color: white;
@@ -324,7 +324,7 @@ html {
 }
 
 #btn-reveal {
-  font-size: 0.5em;
+  font-size: 0.7em;
 }
 
 .mobile #btn-reveal {


### PR DESCRIPTION
#### Description

People set their system- or app-wide font size for a reason: they’re happy with it, it is neither too big nor too small for their eyes. This shouldn’t be messed with by an addon.


#### Checklist:

*Please replace the space inside the brackets with an **x** and fill out the ellipses if the following items apply:*

- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [X] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [x] Latest standard Anki 2.1 binary build [required for Anki-compatible 2.1 add-ons]
  - [ ] Latest alternative Anki 2.1 binary build
  - [ ] Latest Anki 2.0 binary build [required for Anki 2.0-compatible add-ons]
- [X] I've tested my changes on at least one of the following platforms:
  - [x] Linux, version:
  - [ ] Windows, version:
  - [ ] macOS, version: 
- [x] My changes potentially affect non-desktop platforms, of which I've tested:
  - [x] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
