### PR TITLE
Fix for Anki >=2.1.28

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ resources/icons/optional
 # Anki
 src/*/meta.json
 src/*/manifest.json
+tools/
+aqt/
+.pylintrc

--- a/src/cloze_overlapper/editor.py
+++ b/src/cloze_overlapper/editor.py
@@ -290,7 +290,7 @@ def onAddCards(self, _old):
     """Automatically generate overlapping clozes before adding cards"""
     editor = self.editor
     note = editor.note
-    showInfo("Called from onAddCards: "+str(note))
+    # showInfo("Called from onAddCards: "+str(note))
 
     if not note or not checkModel(note.model(), notify=False):
         return _old(self)

--- a/src/cloze_overlapper/editor.py
+++ b/src/cloze_overlapper/editor.py
@@ -290,7 +290,8 @@ def onAddCards(self, _old):
     """Automatically generate overlapping clozes before adding cards"""
     editor = self.editor
     note = editor.note
-    # showInfo("Called from onAddCards: "+str(note))
+    showInfo("Called from onAddCards: "+str(note))
+    showInfo("Model check: "+str(checkModel(note.model()), notify=False))
 
     if not note or not checkModel(note.model(), notify=False):
         return _old(self)

--- a/src/cloze_overlapper/editor.py
+++ b/src/cloze_overlapper/editor.py
@@ -290,7 +290,7 @@ def onAddCards(self, _old):
     """Automatically generate overlapping clozes before adding cards"""
     editor = self.editor
     note = editor.note
-    showInfo(str(note))
+    showInfo("Called from onAddCards: "+str(note))
 
     if not note or not checkModel(note.model(), notify=False):
         return _old(self)

--- a/src/cloze_overlapper/editor.py
+++ b/src/cloze_overlapper/editor.py
@@ -291,7 +291,7 @@ def onAddCards(self, _old):
     editor = self.editor
     note = editor.note
     showInfo("Called from onAddCards: "+str(note))
-    showInfo("Model check: "+str(checkModel(note.model()), notify=False))
+    showInfo("Model check: "+str(checkModel(note.model(), notify=False)))
 
     if not note or not checkModel(note.model(), notify=False):
         return _old(self)

--- a/src/cloze_overlapper/editor.py
+++ b/src/cloze_overlapper/editor.py
@@ -290,8 +290,6 @@ def onAddCards(self, _old):
     """Automatically generate overlapping clozes before adding cards"""
     editor = self.editor
     note = editor.note
-    showInfo("Called from onAddCards: "+str(note))
-    showInfo("Model check: "+str(checkModel(note.model(), notify=False)))
 
     if not note or not checkModel(note.model(), notify=False):
         return _old(self)

--- a/src/cloze_overlapper/editor.py
+++ b/src/cloze_overlapper/editor.py
@@ -290,6 +290,7 @@ def onAddCards(self, _old):
     """Automatically generate overlapping clozes before adding cards"""
     editor = self.editor
     note = editor.note
+    showInfo(str(note))
 
     if not note or not checkModel(note.model(), notify=False):
         return _old(self)

--- a/src/cloze_overlapper/overlapper.py
+++ b/src/cloze_overlapper/overlapper.py
@@ -33,6 +33,8 @@
 Adds overlapping clozes
 """
 
+from aqt.utils import showInfo
+
 from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
 
@@ -203,10 +205,13 @@ class ClozeOverlapper(object):
         # This addon breaks in Anki 2.1.28+ will break due to changes in card-adding behaviour:
         # https://forums.ankiweb.net/t/assign-note-id-to-new-notes-in-addnote-window-revert-a-change-in-2-1-28/2354
         # so if there's no ID, change the hook to use col.backend.add_note(note=note: Note, deck_id=deck_id: int)
+        # Glutanimate has actually acknowledged this already and is doing a bunch of testing
         # yes, i also had to go digging through the code to find this, Damien hasn't written any docs for 2.1
+        # kinda dangerous, don't expect it to do all the right things, I'm not an experienced anki dev
         if note.id == 0:
             ncol = note.col
-            note.id = ncol.backend.add_note(note=note)
+            showInfo(ncol.conf["curDeck"])
+            note.id = ncol.backend.add_note(note=note, deck_id=ncol.conf["curDeck"])
         note.flush()
 
 

--- a/src/cloze_overlapper/overlapper.py
+++ b/src/cloze_overlapper/overlapper.py
@@ -36,8 +36,6 @@ Adds overlapping clozes
 from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
 
-from aqt.utils import showInfo
-
 from .libaddon.platform import ANKI20
 
 import re
@@ -202,7 +200,15 @@ class ClozeOverlapper(object):
             full = full if custom else self.processField(full)
         note[self.flds["fl"]] = full
         note[self.flds["st"]] = createNoteSettings(setopts)
+        # This addon breaks in Anki 2.1.28+ will break due to changes in card-adding behaviour:
+        # https://forums.ankiweb.net/t/assign-note-id-to-new-notes-in-addnote-window-revert-a-change-in-2-1-28/2354
+        # so if there's no ID, change the hook to use col.backend.add_note(note=note: Note, deck_id=deck_id: int)
+        # yes, i also had to go digging through the code to find this, Damien hasn't written any docs for 2.1
+        if note.id == 0:
+            ncol = note.col
+            note.id = ncol.backend.add_note(note=note)
         note.flush()
+
 
     def processField(self, field):
         """Convert field contents back to HTML based on previous markup"""

--- a/src/cloze_overlapper/overlapper.py
+++ b/src/cloze_overlapper/overlapper.py
@@ -1,3 +1,5 @@
+# Thanks to this guy: https://www.reddit.com/r/Anki/comments/jlj1yy/fixing_cloze_overlapper_for_2128/
+
 # -*- coding: utf-8 -*-
 
 # Cloze Overlapper Add-on for Anki
@@ -8,7 +10,7 @@
 # it under the terms of the GNU Affero General Public License as
 # published by the Free Software Foundation, either version 3 of the
 # License, or (at your option) any later version, with the additions
-# listed at the end of the license file that accompanied this program
+# listed at the end of the accompanied license file.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -21,7 +23,7 @@
 # NOTE: This program is subject to certain additional terms pursuant to
 # Section 7 of the GNU Affero General Public License.  You should have
 # received a copy of these additional terms immediately following the
-# terms and conditions of the GNU Affero General Public License that
+# terms and conditions of the GNU Affero General Public License which
 # accompanied this program.
 #
 # If not, please request a copy through one of the means of contact
@@ -33,11 +35,8 @@
 Adds overlapping clozes
 """
 
-from __future__ import (absolute_import, division,
-                        print_function, unicode_literals)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
-from anki.notes import Note
-from aqt.utils import showInfo
 from .libaddon.platform import ANKI20
 
 import re
@@ -75,8 +74,8 @@ class ClozeOverlapper(object):
         original = self.note[self.flds["og"]]
         if not original:
             self.showTT(
-                "Reminder",
-                "Please enter some text in the '%s' field" % self.flds["og"])
+                "Reminder", "Please enter some text in the '%s' field" % self.flds["og"]
+            )
             return False, None
 
         matches = re.findall(self.creg, original)
@@ -90,12 +89,13 @@ class ClozeOverlapper(object):
             items, keys = self.getLineItems(original)
 
         if not items:
-            self.showTT("Warning",
-                        "Could not find any items to cloze.<br>Please check your input.",)
+            self.showTT(
+                "Warning",
+                "Could not find any items to cloze.<br>Please check your input.",
+            )
             return False, None
         if len(items) < 1:
-            self.showTT("Reminder",
-                        "Please enter at least 1 item to cloze.")
+            self.showTT("Reminder", "Please enter at least 1 item to cloze.")
             return False, None
 
         setopts = parseNoteSettings(self.note[self.flds["st"]])
@@ -107,20 +107,25 @@ class ClozeOverlapper(object):
         fields, full, total = gen.generate(items, formstr, keys)
 
         if fields is None:
-            self.showTT("Warning", "This would generate <b>%d</b> overlapping clozes,<br>"
-                        "The note type can only handle a maximum of <b>%d</b> with<br>"
-                        "the current number of %s fields" % (total, maxfields, self.flds["tx"]))
+            self.showTT(
+                "Warning",
+                "This would generate <b>%d</b> overlapping clozes,<br>"
+                "The note type can only handle a maximum of <b>%d</b> with<br>"
+                "the current number of %s fields" % (total, maxfields, self.flds["tx"]),
+            )
             return False, None
         if fields == 0:
-            self.showTT("Warning", "This would generate no overlapping clozes at all<br>"
-                        "Please check your cloze-generation settings")
+            self.showTT(
+                "Warning",
+                "This would generate no overlapping clozes at all<br>"
+                "Please check your cloze-generation settings",
+            )
             return False, None
 
         self.updateNote(fields, full, setopts, custom)
 
         if not self.silent:
-            self.showTT("Info", "Generated %d overlapping clozes" %
-                        total, period=1000)
+            self.showTT("Info", "Generated %d overlapping clozes" % total, period=1000)
         return True, total
 
     def getClozeItems(self, matches):
@@ -152,16 +157,15 @@ class ClozeOverlapper(object):
         else:
             self.markup = "div"
         # remove empty lines:
-        lines = re.sub(r"^(&nbsp;)+$", "", text,
-                       flags=re.MULTILINE).splitlines()
-        items = [line for line in lines if line.strip() != '']
+        lines = re.sub(r"^(&nbsp;)+$", "", text, flags=re.MULTILINE).splitlines()
+        items = [line for line in lines if line.strip() != ""]
         return items, None
 
     @staticmethod
     def getMaxFields(model, prefix):
         """Determine number of text fields available for cloze sequences"""
         m = model
-        fields = [f['name'] for f in m['flds'] if f['name'].startswith(prefix)]
+        fields = [f["name"] for f in m["flds"] if f["name"].startswith(prefix)]
         last = 0
         for f in fields:
             # check for non-continuous cloze fields
@@ -180,8 +184,11 @@ class ClozeOverlapper(object):
             warnUser("Note Type", "Cloze fields not configured properly")
             return False
         elif expected != actual:
-            warnUser("Note Type", "Cloze fields are not continuous."
-                     "<br>(breaking off after %i fields)" % actual)
+            warnUser(
+                "Note Type",
+                "Cloze fields are not continuous."
+                "<br>(breaking off after %i fields)" % actual,
+            )
             return False
         return actual
 
@@ -190,7 +197,7 @@ class ClozeOverlapper(object):
         note = self.note
         options = setopts[1]
         for idx, field in enumerate(fields):
-            name = self.flds["tx"] + str(idx+1)
+            name = self.flds["tx"] + str(idx + 1)
             if name not in note:
                 print("Missing field. Should never happen.")
                 continue
@@ -202,22 +209,8 @@ class ClozeOverlapper(object):
             full = full if custom else self.processField(full)
         note[self.flds["fl"]] = full
         note[self.flds["st"]] = createNoteSettings(setopts)
-        # This addon breaks in Anki 2.1.28+ will break due to changes in card-adding behaviour:
-        # https://forums.ankiweb.net/t/assign-note-id-to-new-notes-in-addnote-window-revert-a-change-in-2-1-28/2354
-        # so if there's no ID, change the hook to use col.backend.add_note(note=note: Note, deck_id=deck_id: int)
-        # Glutanimate has actually acknowledged this already and is doing a bunch of testing
-        # yes, i also had to go digging through the code to find this, Damien hasn't written any docs for 2.1
-        # kinda dangerous, don't expect it to do all the right things, I'm not an experienced anki dev
-        # more problems:
-        # TODO first, it doesn't clear the editor after adding. make it do that.
-        # TODO cards won't add to the collection, how to fix?
-        # TODO i keep getting a poison error, why?
-        if note.id == 0:
-            ncol = note.col
-            note.id = ncol.backend.add_note(note=note.to_backend_note(), deck_id=ncol.conf["curDeck"])
-        else:
+        if note.id != 0:  # Not in add mode
             note.flush()
-
 
     def processField(self, field):
         """Convert field contents back to HTML based on previous markup"""
@@ -226,8 +219,8 @@ class ClozeOverlapper(object):
             tag_start, tag_end = "", ""
             tag_items = "<div>{0}</div>"
         else:
-            tag_start = '<{0}>'.format(markup)
-            tag_end = '</{0}>'.format(markup)
+            tag_start = "<{0}>".format(markup)
+            tag_end = "</{0}>".format(markup)
             tag_items = "<li>{0}</li>"
         lines = "".join(tag_items.format(line) for line in field)
         return tag_start + lines + tag_end

--- a/src/cloze_overlapper/overlapper.py
+++ b/src/cloze_overlapper/overlapper.py
@@ -208,13 +208,15 @@ class ClozeOverlapper(object):
         # Glutanimate has actually acknowledged this already and is doing a bunch of testing
         # yes, i also had to go digging through the code to find this, Damien hasn't written any docs for 2.1
         # kinda dangerous, don't expect it to do all the right things, I'm not an experienced anki dev
+        # more problems:
+        # TODO first, it doesn't clear the editor after adding. make it do that.
+        # TODO cards won't add to the collection, how to fix?
+        # TODO i keep getting a poison error, why?
         if note.id == 0:
             ncol = note.col
-            # showInfo(str(isinstance(note, Note)))
-            # ok this is just bizarre, it says "expected type Note got type Note. for field" Like WTF??? WHY IS THERE A DOT???
-            # nvm i just realised i'm retarded HAHAHAHA
             note.id = ncol.backend.add_note(note=note.to_backend_note(), deck_id=ncol.conf["curDeck"])
-        note.flush()
+        else:
+            note.flush()
 
 
     def processField(self, field):

--- a/src/cloze_overlapper/overlapper.py
+++ b/src/cloze_overlapper/overlapper.py
@@ -214,8 +214,7 @@ class ClozeOverlapper(object):
             # ok this is just bizarre, it says "expected type Note got type Note. for field" Like WTF??? WHY IS THERE A DOT???
             # nvm i just realised i'm retarded HAHAHAHA
             note.id = ncol.backend.add_note(note=note.to_backend_note(), deck_id=ncol.conf["curDeck"])
-        else:
-            note.flush()
+        note.flush()
 
 
     def processField(self, field):

--- a/src/cloze_overlapper/overlapper.py
+++ b/src/cloze_overlapper/overlapper.py
@@ -190,9 +190,12 @@ class ClozeOverlapper(object):
         note = self.note
         if note.id == 0:
             # should fix assertion errors for rust-based versions of anki
-            # new_id = note.col.backend.new_note(self.model["id"])
-            # showInfo("New ID: "+str(new_id))
             note.id = hash(note.guid)
+            showInfo("Note with hashed integer ID: "+str(note))
+            # note.load()
+            showInfo("Note model: "+str(self.model))
+            new_id = note.col.backend.new_note(self.model["id"])
+            showInfo("New ID: "+str(new_id))
         options = setopts[1]
         for idx, field in enumerate(fields):
             name = self.flds["tx"] + str(idx+1)

--- a/src/cloze_overlapper/overlapper.py
+++ b/src/cloze_overlapper/overlapper.py
@@ -188,14 +188,6 @@ class ClozeOverlapper(object):
     def updateNote(self, fields, full, setopts, custom):
         """Write changes to note"""
         note = self.note
-        if note.id == 0:
-            # should fix assertion errors for rust-based versions of anki
-            note.id = hash(note.guid)
-            showInfo("Note with hashed integer ID: "+str(note))
-            # note.load()
-            showInfo("Note model: "+str(self.model))
-            new_id = note.col.backend.new_note(self.model["id"])
-            showInfo("New ID: "+str(new_id))
         options = setopts[1]
         for idx, field in enumerate(fields):
             name = self.flds["tx"] + str(idx+1)

--- a/src/cloze_overlapper/overlapper.py
+++ b/src/cloze_overlapper/overlapper.py
@@ -209,7 +209,6 @@ class ClozeOverlapper(object):
         # kinda dangerous, don't expect it to do all the right things, I'm not an experienced anki dev
         if note.id == 0:
             ncol = note.col
-            showInfo(ncol.conf["curDeck"])
             note.id = ncol.backend.add_note(note=note, deck_id=ncol.conf["curDeck"])
         note.flush()
 

--- a/src/cloze_overlapper/overlapper.py
+++ b/src/cloze_overlapper/overlapper.py
@@ -190,7 +190,7 @@ class ClozeOverlapper(object):
         note = self.note
         if note.id == 0:
             # should fix assertion errors for rust-based versions of anki
-            showInfo(str(note))
+            showInfo("called from overlapper.updateNote: "+str(note))
             new_id = note.col.backend.new_note(self.model["id"])
             note.id = new_id
             note.load()

--- a/src/cloze_overlapper/overlapper.py
+++ b/src/cloze_overlapper/overlapper.py
@@ -186,8 +186,11 @@ class ClozeOverlapper(object):
     def updateNote(self, fields, full, setopts, custom):
         """Write changes to note"""
         note = self.note
-        note.load()
-        self.showTT("Alert", note.id)
+        if note.id == 0:
+            # should fix assertion errors for rust-based versions of anki
+            new_id = note.col.backend.new_note(self.model["id"])
+            note.id = new_id
+            note.load()
         options = setopts[1]
         for idx, field in enumerate(fields):
             name = self.flds["tx"] + str(idx+1)

--- a/src/cloze_overlapper/overlapper.py
+++ b/src/cloze_overlapper/overlapper.py
@@ -192,6 +192,7 @@ class ClozeOverlapper(object):
             # should fix assertion errors for rust-based versions of anki
             showInfo("called from overlapper.updateNote: "+str(note))
             new_id = note.col.backend.new_note(self.model["id"])
+            showInfo("New ID: "+str(new_id))
             note.id = new_id
             note.load()
         options = setopts[1]

--- a/src/cloze_overlapper/overlapper.py
+++ b/src/cloze_overlapper/overlapper.py
@@ -190,11 +190,9 @@ class ClozeOverlapper(object):
         note = self.note
         if note.id == 0:
             # should fix assertion errors for rust-based versions of anki
-            showInfo("called from overlapper.updateNote: "+str(note))
-            new_id = note.col.backend.new_note(self.model["id"])
-            showInfo("New ID: "+str(new_id))
-            note.id = new_id
-            note.load()
+            # new_id = note.col.backend.new_note(self.model["id"])
+            # showInfo("New ID: "+str(new_id))
+            note.id = hash(note.guid)
         options = setopts[1]
         for idx, field in enumerate(fields):
             name = self.flds["tx"] + str(idx+1)

--- a/src/cloze_overlapper/overlapper.py
+++ b/src/cloze_overlapper/overlapper.py
@@ -186,6 +186,7 @@ class ClozeOverlapper(object):
     def updateNote(self, fields, full, setopts, custom):
         """Write changes to note"""
         note = self.note
+        note.load()
         self.showTT("Alert", note.id)
         options = setopts[1]
         for idx, field in enumerate(fields):

--- a/src/cloze_overlapper/overlapper.py
+++ b/src/cloze_overlapper/overlapper.py
@@ -186,6 +186,7 @@ class ClozeOverlapper(object):
     def updateNote(self, fields, full, setopts, custom):
         """Write changes to note"""
         note = self.note
+        self.showTT("Alert", note.id)
         options = setopts[1]
         for idx, field in enumerate(fields):
             name = self.flds["tx"] + str(idx+1)

--- a/src/cloze_overlapper/overlapper.py
+++ b/src/cloze_overlapper/overlapper.py
@@ -36,6 +36,8 @@ Adds overlapping clozes
 from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
 
+from aqt.utils import showInfo
+
 from .libaddon.platform import ANKI20
 
 import re
@@ -188,6 +190,7 @@ class ClozeOverlapper(object):
         note = self.note
         if note.id == 0:
             # should fix assertion errors for rust-based versions of anki
+            showInfo(str(note))
             new_id = note.col.backend.new_note(self.model["id"])
             note.id = new_id
             note.load()

--- a/src/cloze_overlapper/overlapper.py
+++ b/src/cloze_overlapper/overlapper.py
@@ -36,6 +36,7 @@ Adds overlapping clozes
 from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
 
+from anki.notes import Note
 from aqt.utils import showInfo
 from .libaddon.platform import ANKI20
 
@@ -209,6 +210,7 @@ class ClozeOverlapper(object):
         # kinda dangerous, don't expect it to do all the right things, I'm not an experienced anki dev
         if note.id == 0:
             ncol = note.col
+            showInfo(str(isinstance(note, Note)))
             note.id = ncol.backend.add_note(note=note, deck_id=ncol.conf["curDeck"])
         note.flush()
 

--- a/src/cloze_overlapper/overlapper.py
+++ b/src/cloze_overlapper/overlapper.py
@@ -210,8 +210,10 @@ class ClozeOverlapper(object):
         # kinda dangerous, don't expect it to do all the right things, I'm not an experienced anki dev
         if note.id == 0:
             ncol = note.col
-            showInfo(str(isinstance(note, Note)))
-            note.id = ncol.backend.add_note(note=note, deck_id=ncol.conf["curDeck"])
+            # showInfo(str(isinstance(note, Note)))
+            # ok this is just bizarre, it says "expected type Note got type Note. for field" Like WTF??? WHY IS THERE A DOT???
+            # nvm i just realised i'm retarded HAHAHAHA
+            note.id = ncol.backend.add_note(note=note.to_backend_note(), deck_id=ncol.conf["curDeck"])
         note.flush()
 
 

--- a/src/cloze_overlapper/overlapper.py
+++ b/src/cloze_overlapper/overlapper.py
@@ -214,7 +214,8 @@ class ClozeOverlapper(object):
             # ok this is just bizarre, it says "expected type Note got type Note. for field" Like WTF??? WHY IS THERE A DOT???
             # nvm i just realised i'm retarded HAHAHAHA
             note.id = ncol.backend.add_note(note=note.to_backend_note(), deck_id=ncol.conf["curDeck"])
-        note.flush()
+        else:
+            note.flush()
 
 
     def processField(self, field):

--- a/src/cloze_overlapper/overlapper.py
+++ b/src/cloze_overlapper/overlapper.py
@@ -33,11 +33,10 @@
 Adds overlapping clozes
 """
 
-from aqt.utils import showInfo
-
 from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
 
+from aqt.utils import showInfo
 from .libaddon.platform import ANKI20
 
 import re


### PR DESCRIPTION
#### Description

Allows Cloze Overlapper for Anki 2.1 to work on versions >=2.1.28. All credits for the fix go to @phu54321: https://www.reddit.com/r/Anki/comments/jlj1yy/fixing_cloze_overlapper_for_2128/

#### Checklist:

*Please replace the space inside the brackets with an **x** and fill out the ellipses if the following items apply:*

- [X] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [X] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [X] Latest standard Anki 2.1 binary build [required for Anki-compatible 2.1 add-ons]
  - [ ] Latest alternative Anki 2.1 binary build
  - [ ] Latest Anki 2.0 binary build [required for Anki 2.0-compatible add-ons]
- [X] I've tested my changes on at least one of the following platforms:
  - [ ] Linux, version:
  - [X] Windows, version: 10, build 2004
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
