### PR TITLE
Don't flush note when in add mode

### DIFF
--- a/src/cloze_overlapper/overlapper.py
+++ b/src/cloze_overlapper/overlapper.py
@@ -200,7 +200,8 @@ class ClozeOverlapper(object):
             full = full if custom else self.processField(full)
         note[self.flds["fl"]] = full
         note[self.flds["st"]] = createNoteSettings(setopts)
-        note.flush()
+        if note.id != 0:  # Not in add mode
+            note.flush()
 
     def processField(self, field):
         """Convert field contents back to HTML based on previous markup"""


### PR DESCRIPTION
#### Description

Don't flush note when in add mode.

```
Caught exception:
Traceback (most recent call last):
  File "/home/zjosua/.cache/bazel/_bazel_zjosua/1c79c7ac51bf6692c8fc3f9a9a4ef48a/execroot/ankidesktop/bazel-out/k8-fastbuild/bin/qt/runanki.runfiles/ankidesktop/qt/aqt/webview.py", line 546, in handler
    cb(val)
  File "/home/zjosua/.cache/bazel/_bazel_zjosua/1c79c7ac51bf6692c8fc3f9a9a4ef48a/execroot/ankidesktop/bazel-out/k8-fastbuild/bin/qt/runanki.runfiles/ankidesktop/qt/aqt/editor.py", line 528, in <lambda>
    self.web.evalWithCallback("saveNow(%d)" % keepFocus, lambda res: callback())
  File "/home/zjosua/.local/share/Anki2/addons21/cloze_overlapper/editor.py", line 154, in <lambda>
    editor.saveNow(lambda: callback(editor, *args, **kwargs))
  File "/home/zjosua/.local/share/Anki2/addons21/cloze_overlapper/editor.py", line 283, in onOlClozeButton
    return onFieldReady()
  File "/home/zjosua/.local/share/Anki2/addons21/cloze_overlapper/editor.py", line 270, in onFieldReady
    overlapper.add()
  File "/home/zjosua/.local/share/Anki2/addons21/cloze_overlapper/overlapper.py", line 117, in add
    self.updateNote(fields, full, setopts, custom)
  File "/home/zjosua/.local/share/Anki2/addons21/cloze_overlapper/overlapper.py", line 203, in updateNote
    note.flush()
  File "/home/zjosua/.cache/bazel/_bazel_zjosua/1c79c7ac51bf6692c8fc3f9a9a4ef48a/execroot/ankidesktop/bazel-out/k8-fastbuild/bin/qt/runanki.runfiles/ankidesktop/pylib/anki/notes.py", line 81, in flush
    raise Exception("can't flush a new note")
Exception: can't flush a new note
```

#### Checklist:

- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [ ] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [ ] Latest standard Anki 2.1 binary build [required for Anki-compatible 2.1 add-ons]
  - [x] Latest Anki 2.1 dev commit (2df3698e8)
  - [ ] Latest alternative Anki 2.1 binary build
  - [ ] Latest Anki 2.0 binary build [required for Anki 2.0-compatible add-ons]
- [x] I've tested my changes on at least one of the following platforms:
  - [x] Linux, version: Debian bookworm
  - [ ] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
